### PR TITLE
Revert "Better density scaling compatibility"

### DIFF
--- a/core/java/android/content/res/Resources.java
+++ b/core/java/android/content/res/Resources.java
@@ -272,7 +272,7 @@ public class Resources {
             CompatibilityInfo compatInfo, IBinder token) {
         mAssets = assets;
         mMetrics.setToDefaults();
-        mMetrics.forcePersistedDensity();
+        mMetrics.updateDensity();
         if (compatInfo != null) {
             mCompatibilityInfo = compatInfo;
         }
@@ -1917,14 +1917,8 @@ public class Resources {
             if (mConfiguration.densityDpi != Configuration.DENSITY_DPI_UNDEFINED) {
                 mMetrics.densityDpi = mConfiguration.densityDpi;
                 mMetrics.density = mConfiguration.densityDpi * DisplayMetrics.DENSITY_DEFAULT_SCALE;
-
-                final boolean densityScalingSupported = !mCompatibilityInfo.isScalingRequired()
-                        || mCompatibilityInfo.alwaysSupportsScreen();
-                final boolean appScalingRequired = mCompatibilityInfo.neverSupportsScreen()
-                        && mCompatibilityInfo.isScalingRequired();
-                if (densityScalingSupported || appScalingRequired ||
-                        mCompatibilityInfo.equals(CompatibilityInfo.DEFAULT_COMPATIBILITY_INFO)) {
-                    mMetrics.forcePersistedDensity();
+                if (mCompatibilityInfo.equals(CompatibilityInfo.DEFAULT_COMPATIBILITY_INFO)) {
+                    mMetrics.updateDensity();
                 }
             }
             mMetrics.scaledDensity = mMetrics.density * mConfiguration.fontScale;

--- a/core/java/android/util/DisplayMetrics.java
+++ b/core/java/android/util/DisplayMetrics.java
@@ -223,7 +223,7 @@ public class DisplayMetrics {
     public float noncompatYdpi;
 
     /** @hide */
-    public void forcePersistedDensity() {
+    public void updateDensity() {
         density = DENSITY_CURRENT / (float) DENSITY_DEFAULT;
         densityDpi = DENSITY_CURRENT;
         scaledDensity = density;

--- a/core/java/android/view/DisplayInfo.java
+++ b/core/java/android/view/DisplayInfo.java
@@ -444,9 +444,8 @@ public final class DisplayInfo implements Parcelable {
 
         if (!compatInfo.equals(CompatibilityInfo.DEFAULT_COMPATIBILITY_INFO)) {
             compatInfo.applyToDisplayMetrics(outMetrics);
-        } else if (type == Display.TYPE_BUILT_IN
-                && (compatInfo.alwaysSupportsScreen() && !compatInfo.isScalingRequired())) {
-            outMetrics.forcePersistedDensity();
+        } else if (type == Display.TYPE_BUILT_IN) {
+            outMetrics.updateDensity();
         }
     }
 


### PR DESCRIPTION
This isn't the proper solution and seems to cause even more scaling issues with old apps.

This reverts commit f61367b4bf2462ada18dfeac1c4325f749bac47b.

Change-Id: Iafee3dd0409496622557ced3c8b3cf80c5c0faad